### PR TITLE
#561 Interface with only comment (#565)

### DIFF
--- a/src/checks/y_check_constants_interface.clas.abap
+++ b/src/checks/y_check_constants_interface.clas.abap
@@ -8,8 +8,9 @@ CLASS y_check_constants_interface DEFINITION PUBLIC INHERITING FROM y_check_base
 
   PRIVATE SECTION.
     DATA has_something_else TYPE abap_bool VALUE abap_false.
+    DATA has_at_least_one_constant TYPE abap_bool.
 
-    METHODS is_structure_empty IMPORTING structure TYPE sstruc
+    METHODS is_structure_empty IMPORTING structure     TYPE sstruc
                                RETURNING VALUE(result) TYPE abap_bool.
 
     METHODS check_result IMPORTING structure TYPE sstruc.
@@ -18,31 +19,25 @@ ENDCLASS.
 
 
 
-CLASS Y_CHECK_CONSTANTS_INTERFACE IMPLEMENTATION.
+CLASS y_check_constants_interface IMPLEMENTATION.
 
 
   METHOD constructor.
     super->constructor( ).
-
     settings-pseudo_comment = '"#EC CONS_INTF' ##NO_TEXT.
     settings-disable_threshold_selection = abap_true.
     settings-threshold = 0.
     settings-documentation = |{ c_docs_path-checks }constants-interface.md|.
-
     relevant_statement_types = VALUE #( ( scan_struc_stmnt_type-interface ) ).
     relevant_structure_types = VALUE #( ).
-
     set_check_message( 'There are only constants in this interface!' ).
   ENDMETHOD.
 
 
   METHOD inspect_statements.
     CHECK is_structure_empty( structure ) = abap_false.
-
     has_something_else = abap_false.
-
     super->inspect_statements( structure ).
-
     check_result( structure ).
   ENDMETHOD.
 
@@ -51,9 +46,7 @@ CLASS Y_CHECK_CONSTANTS_INTERFACE IMPLEMENTATION.
     CHECK statement-type <> scan_stmnt_type-comment.
     CHECK statement-type <> scan_stmnt_type-comment_in_stmnt.
     CHECK statement-type <> scan_stmnt_type-pragma.
-
     DATA(token) = get_token_abs( statement-from ).
-
     IF token <> 'CONSTANTS'
     AND token <> 'INTERFACE'
     AND token <> 'ENDINTERFACE'
@@ -62,16 +55,17 @@ CLASS Y_CHECK_CONSTANTS_INTERFACE IMPLEMENTATION.
     AND token <> 'OF'.
       has_something_else = abap_true.
     ENDIF.
+    IF token = 'CONSTANTS'.
+      has_at_least_one_constant = abap_true.
+    ENDIF.
   ENDMETHOD.
 
 
   METHOD check_result.
-    CHECK has_something_else = abap_false.
+    CHECK has_something_else = abap_false AND has_at_least_one_constant = abap_true.
 
     DATA(statement_for_message) = ref_scan->statements[ structure-stmnt_from ].
-
     DATA(check_configuration) = detect_check_configuration( statement_for_message ).
-
     raise_error( statement_level = statement_for_message-level
                  statement_index = structure-stmnt_from
                  statement_from = statement_for_message-from

--- a/src/checks/y_check_constants_interface.clas.testclasses.abap
+++ b/src/checks/y_check_constants_interface.clas.testclasses.abap
@@ -54,6 +54,8 @@ ENDCLASS.
 CLASS ltc_empty_interface DEFINITION INHERITING FROM ltc_constants_only FOR TESTING RISK LEVEL HARMLESS DURATION SHORT.
   PROTECTED SECTION.
     METHODS get_code_without_issue REDEFINITION.
+  PRIVATE SECTION.
+
 ENDCLASS.
 
 CLASS ltc_empty_interface IMPLEMENTATION.
@@ -63,9 +65,9 @@ CLASS ltc_empty_interface IMPLEMENTATION.
       ( 'REPORT y_example.' )
 
       ( 'INTERFACE lcl_interface. ' )
+      ( '"has a comment ' )
       ( 'ENDINTERFACE.' )
     ).
   ENDMETHOD.
-
 
 ENDCLASS.


### PR DESCRIPTION
An empty interface should not produce a finding. If it had a comment, then that was a finding. Code changed so that if there are only comments, the interface is nonetheless considered empty.